### PR TITLE
Change conserver transcribe plugin options so that its default output…

### DIFF
--- a/server/plugins/transcribe/__init__.py
+++ b/server/plugins/transcribe/__init__.py
@@ -24,7 +24,6 @@ default_options = {
 }
 model = load_model("base")
 
-options = {}
 
 async def run(vcon_uuid, opts=default_options, ):
     logger.debug("Starting transcribe::run")
@@ -40,6 +39,7 @@ async def run(vcon_uuid, opts=default_options, ):
     vCon.loads(json.dumps(inbound_vcon))
     original_analysis_count = len(vCon.analysis)
 
+    options = opts.get("transcribe_options", {"model_size" : "base", "output_options" : ["vendor"]})
     annotated_vcon = vCon.transcribe(**options)
 
     new_analysis_count = len(annotated_vcon.analysis)


### PR DESCRIPTION
… matches that of the transcription plugin.

There are two transcriptions plugins in the conserver.  I created a clone of transcription and called in transcribe.  Then I refactored it to use the Vcon package filter_plugin for transcribe.  Theoretically they both output the same thing.  I would like to delete the transcription plugin in favor of using the transcribe plugin.  However, I don't want to do this until the current users of the transcription plugin have verified the transcribe plugin works and is compatible with what is expected for output.  This PR can be accepted before the testing as it only changes the newer transcribe plugin which I expect is not used any where yet.