### PR TITLE
Don't default uuid or the domain name used to construct it or users w…

### DIFF
--- a/vcon/__init__.py
+++ b/vcon/__init__.py
@@ -298,8 +298,6 @@ class Vcon():
     self._vcon_dict[Vcon.ATTACHMENTS] = []
     self._vcon_dict[Vcon.CREATED_AT] = vcon.utils.cannonize_date(datetime.datetime.utcnow())
     self._vcon_dict[Vcon.REDACTED] = {}
-    self.set_uuid()
-
 
   def _attempting_modify(self) -> None:
     if(self._state != VconStates.UNSIGNED):
@@ -1114,7 +1112,7 @@ class Vcon():
 
     return(plugin.filter(self, **options))
 
-  def set_uuid(self, domain_name: str="vcon.dev", replace: bool= False) -> str:
+  def set_uuid(self, domain_name: str, replace: bool= False) -> str:
     """
     Generate a UUID for this vCon and set the parameter
 


### PR DESCRIPTION
…ill get lazy and not use their own domain.

If people do not use a different domain, it increases the risk of a duplicate UUID which will cause problems with Vcons which get moved across domains.

Current code which generates new Vcons in the conserver needs to be changed to explicitly call Vcon.set_uuid.  The domain name used in set_uuid should be a configuration parameter for the conserver.  It should not use vcon.dev or default to anything.