### PR TITLE
Add a __str__ representation for vcons

### DIFF
--- a/vcon/__init__.py
+++ b/vcon/__init__.py
@@ -856,6 +856,11 @@ class Vcon():
       return(json.dumps(self._jwe_dict, default=lambda o: o.__dict__, **dumps_options))
 
     raise InvalidVconState("vCon state: {} is not valid for dumps".format(self._state))
+  
+
+  def __str__(self):
+    return self.dumps()
+
 
   def load(self, file_handle: typing.TextIO) -> None:
     """


### PR DESCRIPTION
When uncaught exceptions reach sentry it prints out all the variable in the current scope.  For debugging purposes it would help if the Vcon class had a __str__ method  (see screenshot).

![Annotation - Zoom 2023-06-20 11 36 28](https://github.com/vcon-dev/vcon/assets/84978/82f91e75-88ca-4a75-91fb-07f63328eb6b)
